### PR TITLE
Require reducers properly on hot reload

### DIFF
--- a/src/base/store/ConfigureStore.js
+++ b/src/base/store/ConfigureStore.js
@@ -25,7 +25,7 @@ function configureStore(history, initialState) {
 
   if (module.hot) {
     module.hot.accept('../reducers', () => {
-      const nextRootReducer = require('../reducers');
+      const nextRootReducer = require('../reducers').default;
 
       store.replaceReducer(nextRootReducer);
     });


### PR DESCRIPTION
After editing a reducer the browser will complaint `Error: Expected the nextReducer to be a function.` and the store will not be hot-reloaded.

More info: https://stackoverflow.com/questions/43247696/javascript-require-vs-require-default